### PR TITLE
Install nature_bot_state_publisher_node when 'catkin build' in install mode

### DIFF
--- a/CMakeLists_ros1.cmake
+++ b/CMakeLists_ros1.cmake
@@ -191,6 +191,7 @@ nature_sim_test_node
 nature_gps_to_enu_node
 nature_gps_spoof_node
 nature_path_manager_node
+nature_bot_state_publisher_node
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )


### PR DESCRIPTION
When running the `example.launch` from an installed nature stack, errors are seen due to the lack of this node in the install space